### PR TITLE
Add metadata attribute

### DIFF
--- a/latticejson/schema.json
+++ b/latticejson/schema.json
@@ -25,6 +25,22 @@
       "type": "string",
       "description": "Additional information about the lattice"
     },
+    "metadata": {
+      "type": "object",
+      "description": "Metadata",
+      "additionalProperties": false,
+      "properties": {
+        "creator": {
+          "$ref": "#/definitions/Person"
+        },
+        "editors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        }
+      }
+    },
     "energy": {
       "type": "number",
       "description": "Energy of the particle beam in GeV",
@@ -71,6 +87,23 @@
     }
   },
   "definitions": {
+    "Person": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The person's name."
+        },
+        "email": {
+          "type": "string",
+          "description": "The person's email."
+        }
+      }
+    },
     "Lattice": {
       "type": "array",
       "items": {


### PR DESCRIPTION
Fixes #57

**Example:**

```json
{
    "version": "2.0",
    "title": "FODO Lattice",
    "metadata": {
        "creator": {"name": "Foo Bar"},
        "editors": [{"name": "Foo2 Bar2"}, {"name": "Foo2 Bar2", "email": "foo@bar.com"}]
    },
    "info": "This is the simplest possible strong focusing lattice.",
    "root": "RING",
    "elements": {
        "D1": ["Drift", {"length": 0.55}],
        "Q1": ["Quadrupole", {"length": 0.2, "k1": 1.2}],
        "Q2": ["Quadrupole", {"length": 0.4, "k1": -1.2}],
        "B1": ["Dipole", {"length": 1.5, "angle": 0.392701, "e1": 0.1963505, "e2": 0.1963505}]
    },
    "lattices": {
        "CELL": ["Q1", "D1", "B1", "D1", "Q2", "D1", "B1", "D1", "Q1"],
        "RING": ["CELL", "CELL", "CELL", "CELL", "CELL", "CELL", "CELL", "CELL"]
    }
}
```
